### PR TITLE
Fixes #13. Prior to this fix, a segfault would occur when libusb_init fails.

### DIFF
--- a/core/libusbio.c
+++ b/core/libusbio.c
@@ -52,8 +52,10 @@ int find_camera(int vendorid, int productid)
 				}
 			}
 		}
+
+		libusb_free_device_list(list, 1);
 	}
-	libusb_free_device_list(list, 1);
+
 	return (retcode);
 }
 
@@ -64,7 +66,7 @@ int open_camera(int vendorid, int productid, libusb_device_handle **handle, char
 	libusb_device *found = NULL;
 	ssize_t i = 0;
 	struct libusb_device_descriptor dev_desc;
-	
+
 	if(libusb_init(NULL) == 0)
 	{
 		ssize_t cnt = libusb_get_device_list(NULL, &list);
@@ -107,8 +109,9 @@ int open_camera(int vendorid, int productid, libusb_device_handle **handle, char
 				found = NULL;
 			}
 		}
+
+		libusb_free_device_list(list, 1);
 	}
-	libusb_free_device_list(list, 1);
 	return retcode;
 }
 


### PR DESCRIPTION
The segfault was caused by an attempt to reference items in a usb device list that is never initialized. This fix ensures the items in the list are only referenced and freed if libusb_init succeeds, and thus only if the list is able to be initialized.

@OpenSkyProject I think there is room for improvement on this fix in terms of error recovery. I'm not sure what to do if libusb_init fails -- in my case I saw error -99 (LIBUSB_ERROR_OTHER) which isn't too helpful. Not sure whether you want to terminate the application at this point or just warn the user at the console. But I assume either way, it's best not to segfault. :)