### PR TITLE
Add a fallback for architecture detection in the event that uname -p returns "unknown"

### DIFF
--- a/sbig/install_sbig.bash
+++ b/sbig/install_sbig.bash
@@ -2,6 +2,10 @@
 #Collect parameters in named vars for ease of use
 basedir=$1
 cpu=`uname -p`
+if [[ $cpu == "unknown" ]]
+then
+	cpu=`/usr/bin/lscpu | /bin/grep "Architecture\:" | /bin/sed "s/Architecture\:\s\+//"`
+fi
 bit=`getconf LONG_BIT`
 if [[ $cpu == *arm* ]]
 then


### PR DESCRIPTION
On some platform/architecture combinations, `uname -p` returns "unknown". When this happens on an ARM architecture, this causes the wrong libsbigudrv.so to be installed, which causes the resultant build to fail.

This fix adds a fallback to detect the CPU via `lscpu` if `uname -p` fails. I've verified that it works on raspbian on a Raspberry Pi 3. It should not have any impact on platform/architecture combinations where `uname -p` succeeds.